### PR TITLE
Disable trailing-space and truthy yamllint rules

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  trailing-spaces: disable
+  truthy: disable


### PR DESCRIPTION
The truthy rule reports the following warning which doesn't play well
with Ansible's `become: true`

```
truthy value should be one of [false, true] (truthy)
```

On the other hand, the trailing-space rule doesn't allow us to add
in-line comments, which is sometimes useful. Specially at this early
stage of the project.