### PR TITLE
Create servers with infrastructure role

### DIFF
--- a/inventory/host_vars/staging.donalo.org/config.yml
+++ b/inventory/host_vars/staging.donalo.org/config.yml
@@ -11,3 +11,10 @@ sys_admins:
   - name: pau
     ssh_key: "../pub_keys/pau.pub"
     state: present
+
+servers:
+  - name: "{{ inventory_hostname }}"
+    server_type: cx21
+    image: ubuntu-18.04
+    location: nbg1
+    state: present

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -2,7 +2,7 @@
 donalo.local
 
 [staging]
-staging.donalo.org
+staging.donalo.org ansible_host=78.47.203.39
 
 [donalo:children]
 staging

--- a/roles/infrastructure/tasks/main.yml
+++ b/roles/infrastructure/tasks/main.yml
@@ -12,3 +12,17 @@
     api_token: "{{ hetzner_api_token }}"
   when: item.state == "present"
   with_items: "{{ sys_admins }}"
+
+- name: Create servers
+  hcloud_server:
+    name: "{{ item.name }}"
+    server_type: "{{ item.server_type }}"
+    image: "{{ item.image }}"
+    location: "{{ item.location }}"
+    state: "{{ item.state }}"
+    api_token: "{{ hetzner_api_token }}"
+  with_items: "{{ servers }}"
+  register: "hetzner_servers"
+
+- debug:
+    var: hetzner_servers


### PR DESCRIPTION
This creates the servers specified in the host_vars file but doesn't add
the resulting assigned IP to the `inventory/hosts`. What I did is to
manually copy & paste it from the output. Which was:

```
TASK [infrastructure : debug]
*********************************************************************************************
ok: [staging.donalo.org] => {
  "hetzner_servers": {
    "changed": true,
      "msg": "All items completed",
      "results": [
      {
        "ansible_loop_var":
          "item",
        "changed":
          true,
        "failed":
          false,
        "hcloud_server":
        {
          "backup_window":
            "None",
          "datacenter":
            "nbg1-dc3",
          "id":
            "3656697",
          "image":
            "ubuntu-18.04",
          "ipv4_address":
            "78.47.203.39",
          "ipv6":
            "2a01:4f8:1c0c:4bc3::/64",
          "labels":
          {},
          "location":
            "nbg1",
          "name":
            "staging.donalo.org",
          "rescue_enabled":
            false,
          "server_type":
            "cx21",
          "status":
            "running"
        },
        "invocation":
        {
          "module_args":
          {
            "api_token":
              "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "backups":
              false,
            "datacenter":
              null,
            "endpoint":
              "https://api.hetzner.cloud/v1",
            "force_upgrade":
              false,
            "id":
              null,
            "image":
              "ubuntu-18.04",
            "labels":
              null,
            "location":
              "nbg1",
            "name":
              "staging.donalo.org",
            "rescue_mode":
              null,
            "server_type":
              "cx21",
            "ssh_keys":
              null,
            "state":
              "present",
            "upgrade_disk":
              false,
            "user_data":
              null,
            "volumes":
              null
          }
        },
        "item":
        {
          "image":
            "ubuntu-18.04",
          "location":
            "nbg1",
          "name":
            "staging.donalo.org",
          "server_type":
            "cx21",
          "state":
            "present"
        },
        "root_password":
          XXX
      }
    ]
  }
}

```