### PR TITLE
Cache Python dependencies in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,17 @@ jobs:
       - image: circleci/python:3.7.4-stretch
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-python-deps-{{ checksum "requirements.txt" }}
+            - v1-python-deps-
       - run:
           name: Install dependencies
           command: pip3 install -r requirements.txt --user
+      - save_cache:
+          key: v1-python-deps-{{ checksum "requirements.txt" }}
+          paths:
+            - "~/circleci/.cache/pip"
       - run:
           name: Ansible-lint playbooks
           command: ansible-lint playbooks/*.yml


### PR DESCRIPTION
This will speed up the CI builds which will become useful in upcoming PRs that add a multi-step workflow.