### PR TITLE
Create a Systemd unit to setup Delayed Job

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -5,7 +5,9 @@
     - role: vendor/geerlingguy.security
       vars:
         security_autoupdate_enabled: true
-    - role: webserver
-      tags: webserver
     - role: common
       tags: common
+    - role: webserver
+      tags: webserver
+    - role: background_jobs
+      tags: background_jobs

--- a/roles/background_jobs/tasks/main.yml
+++ b/roles/background_jobs/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Create systemd unit for Delayed Job
+  template:
+    src: delayed_job.service.j2
+    dest: /etc/systemd/system/delayed_job.service
+    mode: 0644
+
+- name: Start the delayed_job service on boot
+  service:
+    name: delayed_job
+    enabled: yes

--- a/roles/background_jobs/templates/delayed_job.service.j2
+++ b/roles/background_jobs/templates/delayed_job.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Donalo Delayed Job
+
+[Service]
+Type=forking
+PIDFile=/var/www/shared/tmp/pids/delayed_job.pid
+RemainAfterExit=no
+Restart=on-failure
+RestartSec=60s
+User=donalo
+SyslogIdentifier=donalo-delayed_job
+ExecStart=/bin/bash -c "/var/www/donalo/current/bin/delayed_job start --pid-dir=/var/www/shared/tmp/pids/"
+ExecStop=/bin/bash -c "/var/www/donalo/current/bin/delayed_job stop --pid-dir=/var/www/shared/tmp/pids/"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Wraps the built-in Delayed Job scripts documented in https://github.com/collectiveidea/delayed_job/#running-jobs in a Systemd unit to properly manage the service.