### PR TITLE
Fix pip cache in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-python-deps-{{ checksum "requirements.txt" }}
-            - v1-python-deps-
+            - v2-python-deps-{{ checksum "requirements.txt" }}
+            - v2-python-deps-
       - run:
           name: Install dependencies
           command: pip3 install -r requirements.txt --user
       - save_cache:
-          key: v1-python-deps-{{ checksum "requirements.txt" }}
+          key: v2-python-deps-{{ checksum "requirements.txt" }}
           paths:
             - "/usr/local/lib/python3.7/site-packages"
       - run:
@@ -31,8 +31,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-python-deps-{{ checksum "requirements.txt" }}
-            - v1-python-deps-
+            - v2-python-deps-{{ checksum "requirements.txt" }}
+            - v2-python-deps-
       - run: pip3 install -r requirements.txt --user
       - run: ansible-galaxy install -r requirements.yml
       - run: echo $VAULT_PASS > .vault_pass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,10 @@ jobs:
             - v2-python-deps-{{ checksum "requirements.txt" }}
             - v2-python-deps-
       - run: pip3 install -r requirements.txt --user
+      - save_cache:
+          key: v2-python-deps-{{ checksum "requirements.txt" }}
+          paths:
+            - "/usr/local/lib/python3.7/site-packages"
       - run: ansible-galaxy install -r requirements.yml
       - run: echo $VAULT_PASS > .vault_pass
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ jobs:
       - image: circleci/python:3.7.4-stretch
     steps:
       - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: |
+          sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:
           keys:
             - v2-python-deps-{{ checksum "requirements.txt" }}
@@ -29,6 +32,9 @@ jobs:
       - image: circleci/python:3.7.4-stretch
     steps:
       - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: |
+          sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:
           keys:
             - v2-python-deps-{{ checksum "requirements.txt" }}


### PR DESCRIPTION
We changed the directory path that gets cached but we didn't invalidate
it which makes us think this is the reasone why `pip` is not picking it
up and re-downloading the dependencies.

Checking with @danypr92 it seems true that dependencies end up in
`/usr/local/lib/python3.7/site-packages` so the `save_cache` `paths`
parameter should be good.