### PR TITLE
Disable SSL certificate generation

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -1,11 +1,5 @@
 ---
 - include_role:
-    name: vendor/coopdevs.certbot_nginx
-  vars:
-    domain_name: "{{ inventory_hostname }}"
-    letsencrypt_email: "{{ certificate_authority_email }}"
-
-- include_role:
     name: vendor/jdauphant.nginx
   vars:
     nginx_configs:


### PR DESCRIPTION
We don't have any *.donalo.org subdomain ready yet so there's no point
on trying and making our CI builds fail. We'll re-enable it once we hear
from donalo (or dig tells us so).