### PR TITLE
Disable HTTPS support until we are ready

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -5,10 +5,9 @@
     nginx_configs:
       upstream:
         - upstream app_server { server unix:{{ unicorn_socket }} fail_timeout=0; }
+    nginx_remove_sites:
+      - donalo_https
     nginx_sites:
-      donalo_https:
-        template: donalo_https.conf.j2
-        server_name: "{{ inventory_hostname }}"
       donalo_http:
         template: donalo_http.conf.j2
         server_name: "{{ inventory_hostname }}"


### PR DESCRIPTION
For reasons I don't understand the following handlers weren't run in other builds

```
RUNNING HANDLER [jdauphant.nginx : reload nginx] *******************************

changed: [staging.donalo.org] => {

    "msg": "checking config first"

}

RUNNING HANDLER [jdauphant.nginx : check nginx configuration] ******************

fatal: [staging.donalo.org]: FAILED! => {"changed": true, "cmd": ["nginx", "-t", "-c", "/etc/nginx/nginx.conf"], "delta": "0:00:00.022280", "end": "2019-11-26 16:06:04.299972", "msg": "non-zero return code", "rc": 1, "start": "2019-11-26 16:06:04.277692", "stderr": "nginx: [emerg] BIO_new_file(\"/etc/letsencrypt/live/staging.donalo.org/fullchain.pem\") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/etc/letsencrypt/live/staging.donalo.org/fullchain.pem','r') error:2006D080:BIO routines:BIO_new_file:no such file)\nnginx: configuration file /etc/nginx/nginx.conf test failed", "stderr_lines": ["nginx: [emerg] BIO_new_file(\"/etc/letsencrypt/live/staging.donalo.org/fullchain.pem\") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/etc/letsencrypt/live/staging.donalo.org/fullchain.pem','r') error:2006D080:BIO routines:BIO_new_file:no such file)", "nginx: configuration file /etc/nginx/nginx.conf test failed"], "stdout": "", "stdout_lines": []}

RUNNING HANDLER [jdauphant.nginx : reload nginx - after config check] **********
```

This makes other builds fail. So as we did with https://github.com/coopdevs/donalo/pull/21, we better wait to be ready for HTTPS. Once that is the case we should revert this and that PR's commit :ok_hand:.