### PR TITLE
Setup Redis as cache store

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -13,3 +13,5 @@
       tags: background_jobs
     - role: database
       tags: database
+    - role: cacheserver
+      tags: cacheserver

--- a/requirements.yml
+++ b/requirements.yml
@@ -8,3 +8,5 @@
   version: 0.0.4
 - src: geerlingguy.mysql
   version: 2.9.5
+- src: davidwittman.redis
+  version: 1.2.7

--- a/roles/cacheserver/tasks/main.yml
+++ b/roles/cacheserver/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- include_role:
+    name: vendor/davidwittman.redis
+  vars:
+    - redis_bind: 127.0.0.1


### PR DESCRIPTION
Redis is, since sharetribe/sharetribe#2786, Sharetribe's prefered cache store although Memcached is still supported.

In terms of feature set, Redis is much more future-proof.