### PR TITLE
Reenable HTTPS

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -6,6 +6,12 @@
     mode: 0644
 
 - include_role:
+    name: vendor/coopdevs.certbot_nginx
+  vars:
+    domain_name: "{{ inventory_hostname }}"
+    letsencrypt_email: "{{ certificate_authority_email }}"
+
+- include_role:
     name: vendor/jdauphant.nginx
   vars:
     nginx_configs:

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -17,9 +17,10 @@
     nginx_configs:
       upstream:
         - upstream app_server { server localhost:8080 fail_timeout=0; }
-    nginx_remove_sites:
-      - donalo_https
     nginx_sites:
+      donalo_https:
+        template: donalo_https.conf.j2
+        server_name: "{{ inventory_hostname }}"
       donalo_http:
         template: donalo_http.conf.j2
         server_name: "{{ inventory_hostname }}"


### PR DESCRIPTION
It simply reverts https://github.com/coopdevs/donalo/pull/23 and https://github.com/coopdevs/donalo/pull/21. Now we do have the next.donalo.org DNS record.