### PR TITLE
Install mysqlclient-dev for mysql gem to compile

### DIFF
--- a/roles/common/tasks/install_packages.yml
+++ b/roles/common/tasks/install_packages.yml
@@ -7,7 +7,8 @@
       'git',
       'apt-transport-https',
       'curl',
-      'wget'
+      'wget',
+      'libmysqlclient-dev'
     ]
     state: present
     force: true


### PR DESCRIPTION
When running `bundle install` the message is

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.                                                                                                           [282/1330]

    current directory: /home/donalo/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/mysql2-0.4.10/ext/mysql2
/home/donalo/.rbenv/versions/2.6.2/bin/ruby -I /home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0 -r ./siteconf20191128-11830-6avqj7.rb extconf.rb
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for ruby/thread.h... yes
checking for rb_thread_call_without_gvl() in ruby/thread.h... yes
checking for rb_thread_blocking_region()... no
checking for rb_wait_for_single_fd()... yes
checking for rb_hash_dup()... yes
checking for rb_intern3()... yes
checking for rb_big_cmp()... yes
checking for mysql_query() in -lmysqlclient... no
-----
mysql client is missing. You may need to 'apt-get install libmysqlclient-dev' or 'yum install mysql-devel', and try again.
-----
```

This package has the headers needed for the mysql2 gem to compile.