### PR TITLE
Create the app dir before deploying

### DIFF
--- a/roles/common/tasks/directories.yml
+++ b/roles/common/tasks/directories.yml
@@ -1,0 +1,8 @@
+---
+- name: Create /var/www/donalo directory
+  file:
+    path: /var/www/donalo
+    owner: "{{ app_user }}"
+    group: "{{ app_user }}"
+    mode: 02775
+    state: directory

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,3 +4,4 @@
 - import_tasks: install_packages.yml
 - import_tasks: secrets.yml
 - import_tasks: locales.yml
+- import_tasks: directories.yml


### PR DESCRIPTION
This way we ensure that the directory is owned by the app_user and thus, Ansistrano is allowed to run the deployment tasks in it.