### PR TITLE
Define rails_enviroment for next.donalo.org

### DIFF
--- a/inventory/host_vars/next.donalo.org/config.yml
+++ b/inventory/host_vars/next.donalo.org/config.yml
@@ -1,4 +1,6 @@
 ---
+rails_environment: staging
+
 sys_admins:
   - name: enrico
     ssh_key: "../pub_keys/enrico.pub"


### PR DESCRIPTION
The `rake db:migrate` task fails because no RAILS_ENV is specified.