### PR TITLE
Install npm with nvm

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -27,3 +27,9 @@
       rbenv_users:
         - donalo
       default_gems_file: files/default-gems
+    - role: vendor/stephdewit.nvm
+      nvm_version: 0.33.11
+      nvm_node_version: 10.15.3
+      become: yes
+      become_user: "{{ app_user }}"
+      tags: nvm

--- a/requirements.yml
+++ b/requirements.yml
@@ -15,3 +15,5 @@
   version: 3.3.0
 - src: zzet.rbenv
   version: 3.4.7
+- src: stephdewit.nvm
+  version: v3.2.0

--- a/roles/common/tasks/install_packages.yml
+++ b/roles/common/tasks/install_packages.yml
@@ -14,6 +14,12 @@
     force: true
     update_cache: true
 
-- name: Install NodeJS (for compiling JavaScript assets)
+- name: Uninstall NodeJS (for compiling JavaScript assets)
   apt:
     name: nodejs
+    state: absent
+
+- name: Uninstall npm
+  apt:
+    name: npm
+    state: absent

--- a/roles/common/tasks/install_packages.yml
+++ b/roles/common/tasks/install_packages.yml
@@ -13,13 +13,3 @@
     state: present
     force: true
     update_cache: true
-
-- name: Uninstall NodeJS (for compiling JavaScript assets)
-  apt:
-    name: nodejs
-    state: absent
-
-- name: Uninstall npm
-  apt:
-    name: npm
-    state: absent


### PR DESCRIPTION
The installation of npm through Ubuntu packages fails due to node-gyp and I can't find how to install that package.

```
$ sudo apt install npm
(...)
The following packages have unmet dependencies:
 npm : Depends: node-gyp (>= 0.10.9) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

I'll try with NVM as Sharetribe does in CI.