### PR TITLE
Serve app traffic from HTTP

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -10,7 +10,7 @@
   vars:
     nginx_configs:
       upstream:
-        - upstream app_server { server unix:{{ unicorn_socket }} fail_timeout=0; }
+        - upstream app_server { server localhost:8080 fail_timeout=0; }
     nginx_remove_sites:
       - donalo_https
     nginx_sites:

--- a/roles/webserver/templates/donalo_http.conf.j2
+++ b/roles/webserver/templates/donalo_http.conf.j2
@@ -2,5 +2,14 @@
 server {
     listen 80;
     server_name {{ item.value.server_name }};
-    return 301 https://$server_name$request_uri;
+
+    location / {
+        proxy_set_header  Host                $host;
+        proxy_set_header  X-Real-IP           $remote_addr;
+        proxy_set_header  X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto   $scheme;
+        proxy_redirect    off;
+        proxy_pass http://app_server;
+    }
+}
 }

--- a/roles/webserver/templates/unicorn.service.j2
+++ b/roles/webserver/templates/unicorn.service.j2
@@ -9,7 +9,7 @@ PIDFile={{ shared_path }}/pids/unicorn.pid
 WorkingDirectory={{ current_path }}
 EnvironmentFile=-/etc/default/donalo
 
-ExecStart=bundle exec unicorn -c {{ current_path }}/config/unicorn.rb -E {{ rails_environment }}
+ExecStart=/home/donalo/.rbenv/bin/rbenv exec bundle exec unicorn -c {{ current_path }}/config/unicorn.rb -E {{ rails_environment }}
 ExecReload=/bin/kill -s USR2 $MAINPID
 ExecStop=/bin/kill -s QUIT $MAINPID
 


### PR DESCRIPTION
This is a follow up from https://github.com/coopdevs/donalo/pull/23 not only we need to disable HTTPS (until we fix it) but we also need to serve app traffic meanwhile. Donalo wants to play with the app.

Note that we also replace the socket with a binding to port 8080, Unicorn's default. This is because so far I only managed to boot it manually running `bundle exec unicorn`.