### PR TITLE
Replace upstream socket with TCP connection

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -3,10 +3,6 @@ ansible_python_interpreter: /usr/bin/python3
 
 app_user: "donalo"
 
-# This path is temporal and will make use of `ansistrano_deploy_to` and
-# `shared_path` once we adopt Ansistrano for deployments
-unicorn_socket: "/var/www/donalo/shared/sockets/unicorn.donalo.sock"
-
 ruby_version: "{{ lookup('file', '../.ruby-version') }}"
 
 hetzner_api_token: !vault |

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -15,7 +15,6 @@
         ansistrano_shared_paths:
           - log
           - pids
-          - sockets
           - public/system
           - public/assets
           - vendor/bundle

--- a/roles/webserver/templates/donalo_http.conf.j2
+++ b/roles/webserver/templates/donalo_http.conf.j2
@@ -12,4 +12,3 @@ server {
         proxy_pass http://app_server;
     }
 }
-}


### PR DESCRIPTION
It's a bit simpler in terms of config. Also, with the current status where the Unicorn service unit can't create files in pids/ or tmp/, this solves at least one of the derived problems.