### PR TITLE
Provide SMTP env vars as Sharetribe expects them

### DIFF
--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -8,10 +8,14 @@ DATABASE_PASSWORD={{ database_password }}
 
 SECRET_KEY_BASE={{ secret_key_base }}
 
-SMTP_EMAIL={{ smtp_email }}
-SMTP_USERNAME={{ smtp_username }}
-SMTP_PASSWORD={{ smtp_password }}
-SMTP_DOMAIN={{ smtp_domain }}
+{% if smtp_email is defined %}
+mail_delivery_method="smtp"
+{% endif %}
+smtp_email_address={{ smtp_email }}
+smtp_email_user_name={{ smtp_username }}
+smtp_email_password={{ smtp_password }}
+smtp_email_domain={{ smtp_domain }}
+smtp_email_port=587
 
 redis_host=localhost
 redis_port=6379


### PR DESCRIPTION
In https://github.com/sharetribe/sharetribe/pull/401 I found out the way the `config/config_loader.rb` works. If we want to override vars defined in `config/config.default.yml` and `config/config.yml` with ENV vars (the simplest from Ansible, I think) the keys of the vars must match.

You can see that in
https://github.com/coopdevs/sharetribe/blob/06a38bdb19bce4e1c60269e2144a3d3abc407c71/config/config_loader.rb#L24.