### PR TITLE
Install imagemagick to handle image processing

### DIFF
--- a/roles/common/tasks/install_packages.yml
+++ b/roles/common/tasks/install_packages.yml
@@ -1,15 +1,15 @@
 ---
 - name: Install base system packages
   apt:
-    name: [
-      'build-essential',
-      'ca-certificates',
-      'git',
-      'apt-transport-https',
-      'curl',
-      'wget',
-      'libmysqlclient-dev'
-    ]
+    pkg:
+      - build-essential
+      - ca-certificates
+      - git
+      - apt-transport-https
+      - curl
+      - wget
+      - libmysqlclient-dev
+      - imagemagick
     state: present
     force: true
     update_cache: true


### PR DESCRIPTION
Image uploads, for instance in listings, don't get displayed because
they fail to get processed by Paperclip, which uses imagemagick under
the hood. I found out from Delayed Job's log:

```
I, [2019-12-18T09:50:10.349512 #26515]  INFO -- : 2019-12-18T09:50:10+0100: [Worker(delayed_job host:staging pid:26515)] Job DelayedPaperclip::ProcessJob [cbef55fd-f13f-45fc-9b8d-ca53d9f21813] from DelayedJob(paperclip) with arguments: ["ListingImage", 8, "image"] (id=1372) (queue=paperclip) RUNNING
E, [2019-12-18T09:50:10.362475 #26515] ERROR -- : 2019-12-18T09:50:10+0100: [Worker(delayed_job host:staging pid:26515)] Job DelayedPaperclip::ProcessJob [cbef55fd-f13f-45fc-9b8d-ca53d9f21813] from DelayedJob(paperclip) with arguments: ["ListingImage", 8, "image"] (id=1372) (queue=paperclip) FAILED (1 prior attempts) with Paperclip::Errors::CommandNotFoundError: Could not run the `identify` command. Please install ImageMagick.
```

Meaningful error messages are sooooo important!