### PR TITLE
Use port 25 instead of 587

### DIFF
--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -15,7 +15,7 @@ smtp_email_address={{ smtp_email }}
 smtp_email_user_name={{ smtp_username }}
 smtp_email_password={{ smtp_password }}
 smtp_email_domain={{ smtp_domain }}
-smtp_email_port=587
+smtp_email_port=25
 
 redis_host=localhost
 redis_port=6379


### PR DESCRIPTION
It was a bet and I failed. I should have tried the following first.

```
pau@staging:/var/www/donalo/current$ curl mail.nexica.com:25
220 cl3-smtp.mail.datacenter.nexica.com ESMTP Postfix
221 2.7.0 Error: I can break rules, too. Goodbye.
pau@staging:/var/www/donalo/current$ curl mail.nexica.com:578
^C
```

578 does not respond from the VPS. Must be closed.