### PR TITLE
Fix SMTP address and domain

### DIFF
--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -11,10 +11,10 @@ SECRET_KEY_BASE={{ secret_key_base }}
 {% if smtp_email is defined %}
 mail_delivery_method="smtp"
 {% endif %}
-smtp_email_address={{ smtp_email }}
+smtp_email_address={{ smtp_domain }}
 smtp_email_user_name={{ smtp_username }}
 smtp_email_password={{ smtp_password }}
-smtp_email_domain={{ smtp_domain }}
+smtp_email_domain={{ inventory_hostname }}
 smtp_email_port=25
 
 redis_host=localhost


### PR DESCRIPTION
I misunderstood the Rails ActionMailer settings, which directly map to Mail's gem and Net::SMTP settings. See: https://github.com/mikel/mail/blob/2.6.6/lib/mail/network/delivery_methods/smtp.rb

I probably got confused with the terms used in Rails and the ones used by Nexica when the passed us the parameters.

From the error backtrace and going up the stack I found out that Net::SMTP address paremeter (See
https://ruby-doc.org/stdlib-2.6.5/libdoc/net/smtp/rdoc/Net/SMTP.html#method-c-new) maps to Sharetribe's `smtp_email_address` ENV var.

The `smtp_email_domain` seems to be Net's SMTP helo_domain (See https://ruby-doc.org/stdlib-2.6.5/libdoc/net/smtp/rdoc/Net/SMTP.html#method-i-start), which I don't really know what it is but seems to be optional. I choose the solution we took in TimeOverflow which is using the server's hostname.