### PR TITLE
Provide domain to generate app-links from

### DIFF
--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -21,3 +21,6 @@ smtp_email_port=25
 redis_host=localhost
 redis_port=6379
 redis_db={{ database_name }}
+
+{# Domain used by the app to generate links #}
+domain={{ inventory_hostname }}


### PR DESCRIPTION
This is needed to make https://github.com/coopdevs/sharetribe/pull/17 work.

The app will get the domain to be used from the `domain` ENV var.