### PR TITLE
Provision the Ruby specified in .ruby-version

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -3,7 +3,8 @@ ansible_python_interpreter: /usr/bin/python3
 
 app_user: "donalo"
 
-ruby_version: "{{ lookup('file', '../.ruby-version') }}"
+# yamllint disable-line rule:line-length
+ruby_version: "{{ lookup('url', 'https://raw.githubusercontent.com/coopdevs/sharetribe/master/.ruby-version') }}"
 
 hetzner_api_token: !vault |
   $ANSIBLE_VAULT;1.1;AES256

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -21,9 +21,9 @@
       rbenv:
         env: user
         version: v1.1.2
-        default_ruby: 2.6.2
+        default_ruby: "{{ ruby_version }}"
         rubies:
-          - version: 2.6.2
+          - version: "{{ ruby_version }}"
       rbenv_users:
         - "{{ app_user }}"
       default_gems_file: files/default-gems


### PR DESCRIPTION
The problem is that the .ruby-version is defined in the app and we can't guarantee we have a copy of the app when provisioning or even where the dev stores it in her machine. Fetching it from Github solves it.