### PR TITLE
Enable Sharetribe's plan service config setting

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -23,3 +23,5 @@ shared_path: "{{ deploy_to }}/shared"
 pids_path: "{{ shared_path }}/pids"
 
 git_version: master
+
+external_plan_service_in_use: true

--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -28,3 +28,5 @@ domain={{ inventory_hostname }}
 google_maps_key={{ google_maps_key }}
 
 app_encryption_key={{ app_encryption_key }}
+
+external_plan_service_in_use={{ external_plan_service_in_use }}


### PR DESCRIPTION
This enables us to create an instance of `PlanService::Store::Plan::PlanModel` and thus, read from
`marketplace_plans` to build the @current_plan. This record can then be updated adding/removing features for Donalo's marketplace.