### PR TITLE
Override translations when deploying

### DIFF
--- a/playbooks/deploy/tasks/after_symlink.yml
+++ b/playbooks/deploy/tasks/after_symlink.yml
@@ -17,6 +17,11 @@
   args:
     chdir: "{{ current_path }}"
 
+- name: override translations
+  shell: bash -lc "bundle exec rake donalo:override_translations"
+  args:
+    chdir: "{{ current_path }}"
+
 # This is mainly meant for setting up a new server, as it won't have
 # a config/ENVIRONMENT.sphinx.conf file yet.
 - name: Check if Sphinx is configured


### PR DESCRIPTION
So we don't have to remember yet another manual action, which is error-prone.

This is rake task is idempotent since Sharetribe itself performs a find or create in https://github.com/coopdevs/sharetribe/blob/master/app/services/translation_service/store/translation.rb#L114-L125.
If the translation was already persisted it'll update it.