### PR TITLE
Dump/restore only when in donalo.org

### DIFF
--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -4,6 +4,7 @@
     state: dump
     name: "{{ old_database }}"
     target: "{{ dump_file_path }}"
+  when: old_database is defined
 
 - include_role:
     name: vendor/geerlingguy.mysql
@@ -26,3 +27,4 @@
     name: "{{ database_name }}"
     state: import
     target: "{{ dump_file_path }}"
+  when: old_database is defined


### PR DESCRIPTION
This adds defensive coding that makes these tasks to be skipped when provisioning next.donalo.org, which just screwed my build
https://app.circleci.com/pipelines/github/coopdevs/donalo/259/workflows/1e4c4047-6097-4084-bdf7-e1163749bbe7/jobs/528.