### PR TITLE
Leave just one location / block on HTTP

### DIFF
--- a/roles/webserver/templates/donalo_http.conf.j2
+++ b/roles/webserver/templates/donalo_http.conf.j2
@@ -4,15 +4,6 @@ server {
     server_name {{ item.value.server_name }};
 
     location / {
-        proxy_set_header  Host                $host;
-        proxy_set_header  X-Real-IP           $remote_addr;
-        proxy_set_header  X-Forwarded-For     $proxy_add_x_forwarded_for;
-        proxy_set_header  X-Forwarded-Proto   $scheme;
-        proxy_redirect    off;
-        proxy_pass http://app_server;
-    }
-
-    location / {
       return 301 https://$host$request_uri;
     }
 }


### PR DESCRIPTION
We were in a hurry and didn't test or pay attention :see_no_evil:. The
site on port 80 should only redirect and not proxy pass. That's 433
responsibility and Nginx tells us already.

```
Jul 07 11:47:05 staging nginx[31445]: nginx: [emerg] duplicate location "/" in /etc/nginx/sites-enabled/donalo_http.conf:15
Jul 07 11:47:05 staging nginx[31445]: nginx: configuration file /etc/nginx/nginx.conf test failed
Jul 07 11:47:05 staging systemd[1]: nginx.service: Control process exited, code=exited status=1
Jul 07 11:47:05 staging systemd[1]: nginx.service: Failed with result 'exit-code'.
Jul 07 11:47:05 staging systemd[1]: Failed to start A high performance web server and a reverse proxy server.
```