### PR TITLE
Increase max file size

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -25,3 +25,5 @@ pids_path: "{{ shared_path }}/pids"
 git_version: master
 
 external_plan_service_in_use: true
+
+max_image_filesize: 10000000 # bytes

--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -34,3 +34,5 @@ external_plan_service_in_use={{ external_plan_service_in_use }}
 use_airbrake={{ use_airbrake }}
 airbrake_project_id={{ airbrake_project_id }}
 airbrake_project_key={{ airbrake_project_key }}
+
+max_image_filesize={{ max_image_filesize }}

--- a/roles/webserver/templates/donalo_https.conf.j2
+++ b/roles/webserver/templates/donalo_https.conf.j2
@@ -11,6 +11,8 @@ server {
 
     server_name {{ item.value.server_name }};
 
+    client_max_body_size 15m;
+
     # Relies on /etc/nginx/conf.d/old_blog_redirects.conf to define the
     # appropriate $new_uri for the given post id
     location ~ post.php {


### PR DESCRIPTION
Set the Nginx's limit up to 15Mb while the app is set to 10Mb this way
requests go through and it's the app server who handles this gracefully.
Only on more desperate situations such as 15Mb we let Nginx shout with
the default error page.

Donalo complained in the first place about that page because they didn't
understand what happened after uploading a >1Mb photo. This approach
solves it.