### PR TITLE
Add each privilege to Metabase DB user individually

### DIFF
--- a/inventory/host_vars/donalo.org/config.yml
+++ b/inventory/host_vars/donalo.org/config.yml
@@ -147,3 +147,21 @@ backups_role_restic_repo_password: !vault |
   62663764633039383463353331663639396463363465383434613037383130383331626432376363
   3266396634643330330a326430636539373166313836383634663530633764303363666262653765
   6136
+
+database_metabase_grants:
+  - "*.*:REQUIRESSL"
+  - "{{ database_name }}.people:SELECT(id, uuid, created_at, updated_at, is_admin, locale, preferences, active_days_count, last_page_load_date, test_group_number, username, reset_password_sent_at, remember_created_at, sign_in_count, current_sign_in_at, last_sign_in_at, given_name, family_name, display_name, phone_number, description, image_updated_at)"
+  - "{{ database_name }}.categories:SELECT"
+  - "{{ database_name }}.comments:SELECT"
+  - "{{ database_name }}.conversations:SELECT"
+  - "{{ database_name }}.follower_relationships:SELECT"
+  - "{{ database_name }}.listings:SELECT"
+  - "{{ database_name }}.locations:SELECT"
+  - "{{ database_name }}.messages:SELECT"
+  - "{{ database_name }}.participations:SELECT"
+  - "{{ database_name }}.shipping_addresses:SELECT"
+  - "{{ database_name }}.stripe_payments:SELECT"
+  - "{{ database_name }}.testimonials:SELECT"
+  - "{{ database_name }}.transactions:SELECT"
+  - "{{ database_name }}.transaction_processes:SELECT"
+  - "{{ database_name }}.transaction_transitions:SELECT"

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -10,3 +10,11 @@
       - name: "{{ database_user }}"
         priv: "{{ database_name }}.*:ALL"
         password: "{{ database_password }}"
+
+- name: Create database user and privileges for Metabase
+  mysql_user:
+    name: "{{ database_metabase_user }}"
+    priv: "{{ item }}"
+    password: "{{ database_metabase_password }}"
+    host: "static.42.151.203.116.clients.your-server.de"
+  loop: "{{ database_metabase_grants }}"


### PR DESCRIPTION
So table-related privileges are easier to add/remove and easier to debug when creating them fails.