### PR TITLE
Provide user_asset_host to build email URLs with

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -27,3 +27,4 @@ git_version: master
 external_plan_service_in_use: true
 
 max_image_filesize: 10000000 # bytes
+user_asset_host: "https://{{ inventory_hostname }}"

--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -24,6 +24,7 @@ redis_db={{ database_name }}
 
 {# Domain used by the app to generate links #}
 domain={{ inventory_hostname }}
+user_asset_host={{ user_asset_host }}
 
 google_maps_key={{ google_maps_key }}
 


### PR DESCRIPTION
This is necessary for the Paperclip config to include the domain in the URLs to assets. We are only experiencing this in emails though.