### PR TITLE
Expose deploy_to as ENV var

### DIFF
--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -37,3 +37,5 @@ airbrake_project_id={{ airbrake_project_id }}
 airbrake_project_key={{ airbrake_project_key }}
 
 max_image_filesize={{ max_image_filesize }}
+
+DEPLOY_TO={{ deploy_to }}


### PR DESCRIPTION
This way we can distinguish between a VPS vs. Heroku deployment. While in the former it is us who controls the working_directory and the log file paths, in the latter the defaults are handled properly by Heroku.